### PR TITLE
Fix the documentation "edit" button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -39,7 +39,7 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/eclipse-lmos/website/edit/main',
+            'https://github.com/eclipse-lmos/website/edit/source',
         },
         blog: {
           showReadingTime: true,


### PR DESCRIPTION
Since our sources are in the `source` branch, we need to link to that branch for editing pages.