### PR TITLE
Address Docusaurus warnings

### DIFF
--- a/blog/AgentDevelopment.md
+++ b/blog/AgentDevelopment.md
@@ -11,6 +11,8 @@ tags: ["AI", "LMOS", "Agents"]
 
 In a world increasingly powered by AI, creating reliable and efficient agents isn’t just about technology but also about processes, strucutures and methodologies. This blog will take you behind the scenes of our agent development, and the various phases involved until production rollout.
 
+<!-- truncate -->
+
 The development of an AI agent, much like a traditional development, begins with a requirements elicitation and documentation phase. However, the agent development has many different and additional phases which we briefly will touch upon in this article. A simplified diagrammatic view of agent development might look something as this:
 
 ![Alt text](/img/agent-development.png)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,6 +43,7 @@ const config = {
         },
         blog: {
           showReadingTime: true,
+          onInlineAuthors: 'ignore',
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           //editUrl:


### PR DESCRIPTION
This fixes the following warnings:

```
[WARNING] Some blog authors used in "AgentDevelopment.md" are not defined in "authors.yml":
- {"name":"Rahul Jamwal","key":null,"page":null}

Note that we recommend to declare authors once in a "authors.yml" file and reference them by key in blog posts front matter to avoid author info duplication.
But if you want to allow inline blog authors, you can disable this message by setting onInlineAuthors: 'ignore' in your blog plugin options.
More info at https://docusaurus.io/docs/blog

[WARNING] Docusaurus found blog posts without truncation markers:
- "blog/AgentDevelopment.md"

We recommend using truncation markers (`<!-- truncate -->` or `{/* truncate */}`) in blog posts to create shorter previews on blog paginated lists.
```